### PR TITLE
feat: add autoConnect option on Android

### DIFF
--- a/BleManager.js
+++ b/BleManager.js
@@ -89,9 +89,9 @@ class BleManager  {
     });
   }
 
-  connect(peripheralId) {
+  connect(peripheralId, autoConnect = false) {
     return new Promise((fulfill, reject) => {
-      bleManager.connect(peripheralId, (error) => {
+      bleManager.connect(peripheralId, autoConnect, (error) => {
         if (error) {
           reject(error);
         } else {

--- a/BleManager.js
+++ b/BleManager.js
@@ -1,6 +1,9 @@
 'use strict';
 var React = require('react-native');
 var bleManager = React.NativeModules.BleManager;
+const Platform = React.Platform;
+
+const isIOS = Platform.OS === 'ios';
 
 class BleManager  {
 
@@ -91,13 +94,15 @@ class BleManager  {
 
   connect(peripheralId, autoConnect = false) {
     return new Promise((fulfill, reject) => {
-      bleManager.connect(peripheralId, autoConnect, (error) => {
+      const cb = (error) => {
         if (error) {
           reject(error);
         } else {
           fulfill();
         }
-      });
+      }
+      const args = isIOS ? [peripheralId, cb] : [peripheralId, autoConnect, cb]
+      bleManager.connect.apply(null, args)
     });
   }
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ BleManager.stopScan()
 
 ```
 
-### connect(peripheralId)
+### connect(peripheralId, autoConnect)
 Attempts to connect to a peripheral. In many case if you can't connect you have to scan for the peripheral before.
 Returns a `Promise` object.
 
@@ -212,6 +212,12 @@ Returns a `Promise` object.
 
 __Arguments__
 - `peripheralId` - `String` - the id/mac address of the peripheral to connect.
+- `autoConnect` - `boolean` - [Android only] defaults to `false`. 
+Whether to directly connect to the peripheral (`false`) or to automatically connect as soon as the peripheral becomes available (`true`). This is useful if you want to re-connect to a known peripheral when it becomes available.
+
+  > Setting this flag to `true` makes the call to **never time out** (a behavior similar to iOS). 
+
+  > Auto connect takes longer than direct connect and **only works for cached or bonded devices**.
 
 __Examples__
 ```js

--- a/android/src/main/java/it/innove/BleManager.java
+++ b/android/src/main/java/it/innove/BleManager.java
@@ -245,7 +245,7 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 	}
 
 	@ReactMethod
-	public void connect(String peripheralUUID, Callback callback) {
+	public void connect(String peripheralUUID, boolean autoConnect, Callback callback) {
 		Log.d(LOG_TAG, "Connect to: " + peripheralUUID);
 
 		Peripheral peripheral = retrieveOrCreatePeripheral(peripheralUUID);
@@ -253,7 +253,7 @@ class BleManager extends ReactContextBaseJavaModule implements ActivityEventList
 			callback.invoke("Invalid peripheral uuid");
 			return;
 		}
-		peripheral.connect(callback, getCurrentActivity());
+		peripheral.connect(callback, getCurrentActivity(), autoConnect);
 	}
 
 	@ReactMethod

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -264,18 +264,6 @@ public class Peripheral extends BluetoothGattCallback {
 		if (newState == BluetoothProfile.STATE_CONNECTED) {
 
 			connected = true;
-
-			new Handler(Looper.getMainLooper()).post(new Runnable() {
-				@Override
-				public void run() {
-					try {
-						gatt.discoverServices();
-					} catch (NullPointerException e) {
-						Log.d(BleManager.LOG_TAG, "onConnectionStateChange connected but gatt of Run method was null");
-					}
-				}
-			});
-
 			sendConnectionEvent(device, "BleManagerConnectPeripheral", status);
 
 			if (connectCallback != null) {

--- a/android/src/main/java/it/innove/Peripheral.java
+++ b/android/src/main/java/it/innove/Peripheral.java
@@ -88,13 +88,13 @@ public class Peripheral extends BluetoothGattCallback {
 		Log.d(BleManager.LOG_TAG, "Peripheral event (" + eventName + "):" + device.getAddress());
 	}
 
-	public void connect(Callback callback, Activity activity) {
+	public void connect(Callback callback, Activity activity, boolean autoConnect) {
 		if (!connected) {
 			BluetoothDevice device = getDevice();
 			this.connectCallback = callback;
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 				Log.d(BleManager.LOG_TAG, " Is Or Greater than M $mBluetoothDevice");
-				gatt = device.connectGatt(activity, false, this, BluetoothDevice.TRANSPORT_LE);
+				gatt = device.connectGatt(activity, autoConnect, this, BluetoothDevice.TRANSPORT_LE);
 			} else {
 				Log.d(BleManager.LOG_TAG, " Less than M");
 				try {
@@ -102,11 +102,11 @@ public class Peripheral extends BluetoothGattCallback {
 					Method m = device.getClass().getDeclaredMethod("connectGatt", Context.class, Boolean.class, BluetoothGattCallback.class, Integer.class);
 					m.setAccessible(true);
 					Integer transport = device.getClass().getDeclaredField("TRANSPORT_LE").getInt(null);
-					gatt = (BluetoothGatt) m.invoke(device, activity, false, this, transport);
+					gatt = (BluetoothGatt) m.invoke(device, activity, autoConnect, this, transport);
 				} catch (Exception e) {
 					e.printStackTrace();
 					Log.d(TAG, " Catch to call normal connection");
-					gatt = device.connectGatt(activity, false,
+					gatt = device.connectGatt(activity, autoConnect,
 							this);
 				}
 			}

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ declare module 'react-native-ble-manager' {
     
 	export function scan(serviceUUIDs: string[], seconds: number, allowDuplicates?: boolean, options?: ScanOptions): Promise<void>;
 	export function stopScan(): Promise<void>;
-	export function connect(peripheralID: string): Promise<void>
+	export function connect(peripheralID: string, autoConnect?: boolean): Promise<void>
 	export function disconnect(peripheralID: string, force?:boolean): Promise<void>
 	export function checkState(): void;
 	export function startNotification(peripheralID: string, serviceUUID: string, characteristicUUID: string): Promise<void>


### PR DESCRIPTION
Adds the `autoConnect` flag on Android:

Whether to directly connect to the peripheral (`false`) or to automatically connect as soon as the peripheral becomes available (`true`). This is useful if you want to re-connect to a known peripheral when it becomes available.